### PR TITLE
Redesign DevSecNews narrative structure

### DIFF
--- a/docs/banners/2026-04/devsecnews_2026_04_banner_A4_color_final.svg
+++ b/docs/banners/2026-04/devsecnews_2026_04_banner_A4_color_final.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="320" viewBox="0 0 1600 320">
+<defs>
+<linearGradient id="bg" x1="0" x2="1"><stop offset="0%" stop-color="#03070b"/><stop offset="62%" stop-color="#06121a"/><stop offset="100%" stop-color="#03070b"/></linearGradient>
+<radialGradient id="g1" cx="78%" cy="66%" r="52%"><stop offset="0%" stop-color="#11c7cd" stop-opacity=".18"/><stop offset="100%" stop-color="#11c7cd" stop-opacity="0"/></radialGradient>
+<radialGradient id="g2" cx="38%" cy="18%" r="45%"><stop offset="0%" stop-color="#f8f5ef" stop-opacity=".08"/><stop offset="100%" stop-color="#f8f5ef" stop-opacity="0"/></radialGradient>
+<filter id="shadow"><feDropShadow dx="0" dy="10" stdDeviation="8" flood-color="#000000" flood-opacity="0.35"/></filter>
+<style>
+.kr{font-family:Inter,'Noto Sans KR','Apple SD Gothic Neo','Malgun Gothic',Arial,sans-serif}
+.brand{font-size:17px;font-weight:900;fill:#f6f8fa;letter-spacing:.02em}.small{font-size:14px;font-weight:800;fill:#bec1c8}.status{font-size:35px;font-weight:900;fill:#0b121d}.micro{font-size:13px;fill:#aeb2b8}.q{font-size:65px;font-weight:900;fill:#f8f5ef}.sub{font-size:21px;font-weight:900;fill:#f6f8fa}.sub2{font-size:18px;fill:#b4bac3}.cta{font-size:22px;font-weight:900;fill:#26e1e6}.label{font-size:13px;font-weight:900;fill:#26e1e6;letter-spacing:.04em}
+</style>
+</defs>
+<rect width="1600" height="320" fill="url(#bg)"/><rect width="1600" height="320" fill="url(#g1)"/><rect width="1600" height="320" fill="url(#g2)"/>
+<g stroke="#ffffff" opacity=".025"><path d="M0 120H1600M0 240H1600"/><path d="M120 0V320M240 0V320M360 0V320M480 0V320M600 0V320M720 0V320M840 0V320M960 0V320M1080 0V320M1200 0V320M1320 0V320M1440 0V320M1560 0V320"/></g>
+<text x="42" y="43" class="kr brand">DEVSECNEWS</text><text x="168" y="43" class="kr small">2026년 4월호</text>
+<rect x="1360" y="24" width="185" height="28" rx="14" fill="#000000" opacity=".35" stroke="#11c7cd" stroke-opacity=".65"/>
+<text x="1380" y="43" class="kr label">DEFAULT DESIGN</text>
+<g class="kr" filter="url(#shadow)">
+<rect x="60" y="76" width="350" height="86" rx="20" fill="#f8f5ef" stroke="#11c7cd" stroke-opacity=".55"/>
+<circle cx="102" cy="119" r="15" fill="#11c7cd"/><path d="M94 119 L100 126 L112 110" stroke="#f8f5ef" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="138" y="132" class="status">설치 완료</text><text x="78" y="185" class="micro">postinstall은 기록됐습니까?</text><rect x="298" y="181" width="80" height="3" rx="2" fill="#11c7cd" opacity=".55"/>
+<rect x="442" y="76" width="350" height="86" rx="20" fill="#f8f5ef" stroke="#11c7cd" stroke-opacity=".55"/>
+<circle cx="484" cy="119" r="15" fill="#11c7cd"/><path d="M476 119 L482 126 L494 110" stroke="#f8f5ef" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="520" y="132" class="status">설정 저장</text><text x="460" y="185" class="micro">도구 호출은 승인됐습니까?</text><rect x="680" y="181" width="80" height="3" rx="2" fill="#11c7cd" opacity=".55"/>
+<rect x="824" y="76" width="350" height="86" rx="20" fill="#f8f5ef" stroke="#11c7cd" stroke-opacity=".55"/>
+<circle cx="866" cy="119" r="15" fill="#11c7cd"/><path d="M858 119 L864 126 L876 110" stroke="#f8f5ef" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="902" y="132" class="status">로그인 성공</text><text x="842" y="185" class="micro">이후 흐름은 보입니까?</text><rect x="1062" y="181" width="80" height="3" rx="2" fill="#11c7cd" opacity=".55"/>
+</g>
+<g class="kr"><text x="62" y="287" class="q">정말 끝난 걸까요?</text><rect x="64" y="306" width="416" height="5" rx="3" fill="#26e1e6"/>
+<text x="650" y="259" class="sub">완료 뒤의 실행과 기록을 봅니다.</text><text x="650" y="289" class="sub2">npm install · AI 도구 설정 · 로그인 이후 흐름</text>
+<rect x="1240" y="230" width="278" height="42" rx="12" fill="#050c11" opacity=".92" stroke="#26e1e6" stroke-width="2"/><text x="1264" y="259" class="cta">4월호에서 확인하기 →</text></g>
+</svg>

--- a/docs/banners/2026-04/devsecnews_2026_04_banner_A_final.svg
+++ b/docs/banners/2026-04/devsecnews_2026_04_banner_A_final.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="320" viewBox="0 0 1600 320">
+<defs>
+<linearGradient id="bg" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#020617"/><stop offset="58%" stop-color="#061827"/><stop offset="100%" stop-color="#020617"/></linearGradient>
+<radialGradient id="g1" cx="74%" cy="45%" r="50%"><stop offset="0%" stop-color="#22d3ee" stop-opacity=".28"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
+<style>
+.kr{font-family:Inter,'Noto Sans KR',Arial,sans-serif}
+.brand{font-size:18px;font-weight:900;fill:#bdf7ff}
+.small{font-size:15px;font-weight:800;fill:#aab8c6}
+.h{font-size:43px;font-weight:900;fill:#f8fbff}
+.q{font-size:57px;font-weight:900;fill:#22d3ee}
+.body{font-size:20px;fill:#cdd9e4}
+.chip{font-size:20px;font-weight:900;fill:#f8fbff}
+.trace{font-size:15px;fill:#aab8c6}
+.cta{font-size:22px;font-weight:900;fill:#001f25}
+</style>
+</defs>
+<rect width="1600" height="320" fill="url(#bg)"/><rect width="1600" height="320" fill="url(#g1)"/>
+<g opacity=".11" stroke="#22d3ee"><path d="M0 40H1600M0 80H1600M0 120H1600M0 160H1600M0 200H1600M0 240H1600M0 280H1600"/><path d="M40 0V320M80 0V320M120 0V320M160 0V320M200 0V320M240 0V320M280 0V320M320 0V320M360 0V320M400 0V320M440 0V320M480 0V320M520 0V320M560 0V320M600 0V320M640 0V320M680 0V320M720 0V320M760 0V320M800 0V320M840 0V320M880 0V320M920 0V320M960 0V320M1000 0V320M1040 0V320M1080 0V320M1120 0V320M1160 0V320M1200 0V320M1240 0V320M1280 0V320M1320 0V320M1360 0V320M1400 0V320M1440 0V320M1480 0V320M1520 0V320M1560 0V320"/></g>
+<rect x="30" y="18" width="144" height="32" rx="7" fill="#22d3ee" opacity=".16" stroke="#22d3ee" stroke-opacity=".55"/>
+<text x="47" y="40" class="kr brand">DEVSECNEWS</text>
+<text x="190" y="40" class="kr small">2026년 4월호 · Security Default Design</text>
+<text x="54" y="114" class="kr h">설치 완료.</text>
+<text x="54" y="167" class="kr h">설정 저장.</text>
+<text x="54" y="220" class="kr h">로그인 성공.</text>
+<text x="54" y="286" class="kr q">정말 끝난 걸까요?</text>
+<text x="54" y="306" class="kr body">정상 처리 뒤에서 무엇이 실행되고, 무엇이 기록되지 않았는지 봅니다.</text>
+<g class="kr">
+<rect x="870" y="82" width="282" height="50" rx="13" fill="#0f172a" opacity=".92" stroke="#22d3ee" stroke-width="2"/><circle cx="896" cy="107" r="8" fill="#22d3ee"/><text x="916" y="114" class="chip">npm install</text>
+<rect x="870" y="148" width="282" height="50" rx="13" fill="#0f172a" opacity=".92" stroke="#a78bfa" stroke-width="2"/><circle cx="896" cy="173" r="8" fill="#a78bfa"/><text x="916" y="180" class="chip">AI 도구 설정</text>
+<rect x="870" y="214" width="282" height="50" rx="13" fill="#0f172a" opacity=".92" stroke="#fb923c" stroke-width="2"/><circle cx="896" cy="239" r="8" fill="#fb923c"/><text x="916" y="246" class="chip">로그인 성공</text>
+<text x="1192" y="111" font-size="15" fill="#22d3ee">postinstall?</text>
+<text x="1192" y="177" font-size="15" fill="#a78bfa">tool call?</text>
+<text x="1192" y="243" font-size="15" fill="#fb923c">value transfer?</text>
+<text x="1412" y="110" class="trace" opacity=".72">not always visible</text>
+<text x="1412" y="176" class="trace" opacity=".72">not always visible</text>
+<text x="1412" y="242" class="trace" opacity=".72">not always visible</text>
+</g>
+<rect x="1280" y="258" width="282" height="44" rx="10" fill="#22d3ee"/>
+<text x="1302" y="287" class="kr cta">4월호에서 확인하기 →</text>
+</svg>

--- a/docs/structure/devsecnews-narrative-structure-v2.md
+++ b/docs/structure/devsecnews-narrative-structure-v2.md
@@ -65,21 +65,48 @@ This is not a summary of all issues. It is the interpretive lens for the month.
 ### Requirements
 
 - One memorable sentence.
-- Avoid package names in the first line unless the package itself is the story.
+- Avoid abstract security slogans.
+- Prefer concrete surfaces from the month: commands, settings, flows, interfaces, permissions, evidence.
 - Avoid direct instruction too early.
-- Prefer a sentence that creates curiosity and frames the rest of the report.
+- Prefer a sentence or question that creates curiosity and frames the rest of the report.
 
-### 2026-04 example
+### 2026-04 recommended title
+
+```text
+개발 패키지 설치 명령(npm install), AI 도구 설정, 로그인 성공 — 어디까지 보이고 있습니까?
+```
+
+This title is intentionally concrete. It names the three surfaces that made April different:
+
+```text
+Build: 개발 패키지 설치 명령(npm install)
+Config: AI 도구 설정
+Account: 로그인 성공
+```
+
+It avoids the generic phrase `공격 경로` in the headline and turns the issue into a visibility question.
+
+### Supporting line
+
+```text
+4월호는 설치, 설정, 계정 흐름 뒤에서 실제로 무엇이 실행되고 기록되는지 묻습니다.
+```
+
+### Avoid as opening thesis
 
 ```text
 실행은 조용히 지나가고, 사고는 나중에 보입니다.
 ```
 
-Alternative:
+This is conceptually accurate, but too literary and not clickable enough as a headline.
+
+Also avoid:
 
 ```text
-보이지 않는 실행 경로가 이번 달의 공통 신호였습니다.
+평범한 흐름이 공격 경로가 됐다
 ```
+
+This is too generic and can describe almost any security incident.
 
 ## 2. Pattern
 
@@ -234,10 +261,10 @@ What does this incident teach us about visibility, ownership, defaults, or decis
 
 ```markdown
 # DevSecNews 2026-04
-## 실행은 조용히 지나가고, 사고는 나중에 보입니다
+## 개발 패키지 설치 명령(npm install), AI 도구 설정, 로그인 성공 — 어디까지 보이고 있습니까?
 
 ## 1. Signal
-보이지 않는 실행 경로가 이번 달의 공통 신호였습니다.
+4월호는 설치, 설정, 계정 흐름 뒤에서 실제로 무엇이 실행되고 기록되는지 묻습니다.
 
 ## 2. Pattern
 - Axios: 설치가 실행이 되었습니다.
@@ -296,13 +323,13 @@ Each monthly issue should contain one polished thesis, not many competing slogan
 For 2026-04, recommended thesis:
 
 ```text
-실행은 조용히 지나가고, 사고는 나중에 보입니다.
+개발 패키지 설치 명령(npm install), AI 도구 설정, 로그인 성공 — 어디까지 보이고 있습니까?
 ```
 
 Supporting line:
 
 ```text
-보이지 않는 실행 경로는 기본적으로 기록되고 소유되어야 합니다.
+4월호는 설치, 설정, 계정 흐름 뒤에서 실제로 무엇이 실행되고 기록되는지 묻습니다.
 ```
 
 Avoid leading with:

--- a/docs/structure/devsecnews-narrative-structure-v2.md
+++ b/docs/structure/devsecnews-narrative-structure-v2.md
@@ -1,0 +1,314 @@
+# DevSecNews Narrative Structure v2
+
+## Purpose
+
+DevSecNews should evolve from a monthly vulnerability summary into a monthly design review of security knowledge.
+
+The goal is not to make readers memorize every control or default. The goal is to explain, month by month, **why certain security knowledge must move from human attention into default design, platform guardrails, visibility, and decision interfaces**.
+
+This structure is based on the philosophy from `security-knowledge-to-default-design`:
+
+```text
+Some security knowledge should be embedded into defaults.
+Some security knowledge should remain a human decision.
+Some security knowledge must be created together through team discussion.
+```
+
+DevSecNews should therefore answer four questions every month:
+
+```text
+What signal did this month reveal?
+What pattern connects the incidents?
+What design gap made the pattern possible?
+What should become default, visible, or explicitly decided?
+```
+
+## Why the old structure is not enough
+
+The old Node.js / Java / Common taxonomy is useful for lookup, but it makes the report feel like a classified advisory digest. That is not the strongest identity for DevSecNews.
+
+DevSecNews should lead with meaning, not taxonomy.
+
+The technical details still matter, but they should support the monthly thesis. They should not be the first organizing principle.
+
+## New structure
+
+```markdown
+# DevSecNews YYYY-MM
+## <Monthly Thesis>
+
+## 1. Signal
+## 2. Pattern
+## 3. Design Failure
+## 4. Default Shift
+## 5. Decision Point
+## 6. Team Conversation
+## 7. Field Notes
+```
+
+The reading flow becomes:
+
+```text
+Signal -> Pattern -> Design Failure -> Default Shift -> Decision Point -> Team Conversation -> Technical Evidence
+```
+
+This is intentionally different from a CVE digest.
+
+## 1. Signal
+
+### Role
+
+Open with the one signal this month is sending.
+
+This is not a summary of all issues. It is the interpretive lens for the month.
+
+### Requirements
+
+- One memorable sentence.
+- Avoid package names in the first line unless the package itself is the story.
+- Avoid direct instruction too early.
+- Prefer a sentence that creates curiosity and frames the rest of the report.
+
+### 2026-04 example
+
+```text
+실행은 조용히 지나가고, 사고는 나중에 보입니다.
+```
+
+Alternative:
+
+```text
+보이지 않는 실행 경로가 이번 달의 공통 신호였습니다.
+```
+
+## 2. Pattern
+
+### Role
+
+Show the repeated pattern across incidents.
+
+This section answers:
+
+```text
+What did these incidents have in common?
+```
+
+### 2026-04 example
+
+```text
+Axios: package installation became code execution.
+MCP: configuration became local tool execution.
+ATO: login became stored-value monetization.
+```
+
+The point is not that developers forgot something. The point is that execution occurred through ordinary-looking paths.
+
+## 3. Design Failure
+
+### Role
+
+Explain the design gap behind the pattern.
+
+This is the philosophical center of the report.
+
+It should avoid shallow explanations such as:
+
+```text
+Users should be more careful.
+Developers should remember this.
+Teams should read the advisory.
+```
+
+Instead, it should explain why the issue escapes human attention:
+
+```text
+The execution path was not visible.
+It looked like normal work.
+Evidence was not preserved by default.
+Ownership of the path was unclear.
+```
+
+### 2026-04 example
+
+```text
+The April incidents were not primarily memory failures. They were visibility and ownership failures. Installation, configuration, and account flows all looked like normal operations, but each carried execution or monetization power that was not visible by default.
+```
+
+## 4. Default Shift
+
+### Role
+
+Translate the design failure into a shift in default thinking.
+
+This is not a checklist. It is a before/after change in mental model.
+
+### Format
+
+| Area | Old default | New default |
+|---|---|---|
+| Build | Installation resolves dependencies | Installation can execute code |
+| Config | Tool configuration is personal productivity | Tool configuration is an execution boundary |
+| Account | Login is the security event | Post-login value movement is also the security event |
+
+### 2026-04 examples
+
+```text
+Build logs should not be treated as secondary debugging artifacts. They are primary evidence for supply-chain compromise.
+```
+
+```text
+MCP configuration should not be treated as personal developer preference. It is a declaration of tool execution authority.
+```
+
+```text
+ATO detection should not end at authentication. Stored-value movement is where the business impact is completed.
+```
+
+## 5. Decision Point
+
+### Role
+
+Separate what can become default from what must remain a human decision.
+
+This prevents DevSecNews from becoming an automation-only manifesto.
+
+### Questions to include
+
+```text
+What can be embedded as a default?
+What must be reviewed as an exception?
+Who owns the decision?
+What evidence is required for that decision?
+```
+
+### 2026-04 examples
+
+```text
+Should this CI environment be treated as compromised and trigger credential rotation?
+Should this MCP tool be approved as a team-standard integration?
+Should this ATO cluster be escalated from anomaly monitoring to incident response?
+```
+
+## 6. Team Conversation
+
+### Role
+
+Create shared knowledge that cannot be fully automated or transmitted as a rule.
+
+This is where DevSecNews becomes a team conversation starter rather than a static advisory.
+
+### 2026-04 examples
+
+```text
+Which execution paths in our team are invisible until something breaks?
+Which developer-local settings create organization-level risk?
+Which post-login value movements are security events rather than product events?
+```
+
+## 7. Field Notes
+
+### Role
+
+Put technical details here.
+
+Node.js, Java, CVEs, affected versions, references, and tool notes still belong in the report, but as evidence and implementation material.
+
+### Suggested subsections
+
+```markdown
+## 7.1 Node.js / npm
+## 7.2 Java / Spring / JVM
+## 7.3 AI / MCP / Development Environment
+## 7.4 Account Security / ATO
+## 7.5 Tools and References
+```
+
+Every major technical item should include:
+
+```text
+Default-design takeaway:
+What does this incident teach us about visibility, ownership, defaults, or decision boundaries?
+```
+
+## 2026-04 structure example
+
+```markdown
+# DevSecNews 2026-04
+## 실행은 조용히 지나가고, 사고는 나중에 보입니다
+
+## 1. Signal
+보이지 않는 실행 경로가 이번 달의 공통 신호였습니다.
+
+## 2. Pattern
+- Axios: 설치가 실행이 되었습니다.
+- MCP: 설정이 로컬 도구 실행으로 이어졌습니다.
+- ATO: 로그인 이후 자산 흐름에서 피해가 완성됐습니다.
+
+## 3. Design Failure
+이번 이슈들은 사람이 기억하지 못해서만 발생한 문제가 아닙니다. 실행 경로가 정상 흐름 안에 숨어 있었고, 그 경로가 기본적으로 기록·검토·소유되지 않았기 때문입니다.
+
+## 4. Default Shift
+| Area | Old default | New default |
+|---|---|---|
+| Build | Installation resolves dependencies | Installation can execute code |
+| Config | Tool configuration is personal productivity | Tool configuration is an execution boundary |
+| Account | Login is the security event | Post-login value movement is also the security event |
+
+## 5. Decision Point
+- Which build environments should be treated as compromised?
+- Which MCP tools should be approved as team standards?
+- Which ATO flows should be escalated to incident response?
+
+## 6. Team Conversation
+- Where are our invisible execution paths?
+- What evidence would we need after an incident?
+- Which defaults should platform/security teams own?
+
+## 7. Field Notes
+- Axios npm supply-chain compromise
+- PoisonChain
+- MCP / AI development environment
+- mcpguard
+- ATO supply chain
+- PointPivot
+- Spring / Java advisories
+```
+
+## Relationship to existing pipeline
+
+This PR does not yet change build scripts. It proposes a content structure that can be adopted first by the 2026-04 issue.
+
+If the HTML/card generator assumes fixed numbered sections, the generator should be updated later to recognize semantic sections rather than fixed numeric labels.
+
+Recommended migration path:
+
+```text
+Phase 1: Add this structure guide.
+Phase 2: Rewrite 2026-04 content using this structure.
+Phase 3: Update card-generation prompt/template to use Signal / Pattern / Default Shift.
+Phase 4: Update renderer if section anchors or cards depend on the old numbering.
+```
+
+## Editorial rule
+
+Each monthly issue should contain one polished thesis, not many competing slogans.
+
+For 2026-04, recommended thesis:
+
+```text
+실행은 조용히 지나가고, 사고는 나중에 보입니다.
+```
+
+Supporting line:
+
+```text
+보이지 않는 실행 경로는 기본적으로 기록되고 소유되어야 합니다.
+```
+
+Avoid leading with:
+
+```text
+자동 실행 경로를 통제하세요
+```
+
+That sentence is actionable, but it is too directive for the opening thesis. It can be used later in Default Shift or CTA copy.


### PR DESCRIPTION
## Summary

This PR proposes a new narrative structure for DevSecNews.

Instead of leading with a Node.js / Java / Common taxonomy, the new structure makes DevSecNews a monthly design review of security knowledge:

```text
Signal -> Pattern -> Design Failure -> Default Shift -> Decision Point -> Team Conversation -> Field Notes
```

The goal is to explain why some security knowledge should become defaults, visibility, guardrails, and explicit decision interfaces, rather than asking readers to memorize every control.

## Why

The current structure is useful as an advisory digest, but it does not fully express the philosophy from `security-knowledge-to-default-design`:

- some knowledge belongs in defaults,
- some belongs in human decisions,
- some must be created together by teams.

The proposed structure lets each issue start with a polished monthly thesis, then use incidents as evidence for a design failure and a default shift.

## Proposed structure

```markdown
# DevSecNews YYYY-MM
## <Monthly Thesis>

## 1. Signal
## 2. Pattern
## 3. Design Failure
## 4. Default Shift
## 5. Decision Point
## 6. Team Conversation
## 7. Field Notes
```

## 2026-04 example thesis

```text
실행은 조용히 지나가고, 사고는 나중에 보입니다.
```

Supporting line:

```text
보이지 않는 실행 경로는 기본적으로 기록되고 소유되어야 합니다.
```

## Files

- `docs/structure/devsecnews-narrative-structure-v2.md`

## Notes

This PR does not change the generator yet. Recommended migration:

1. Add this structure guide.
2. Rewrite 2026-04 content using the structure.
3. Update card-generation prompt/template.
4. Update renderer only if old section anchors are hard-coded.
